### PR TITLE
Added Task and State ordering to Zustand Store

### DIFF
--- a/src/templates/KanbanBoard/AddStateModal.test.tsx
+++ b/src/templates/KanbanBoard/AddStateModal.test.tsx
@@ -19,12 +19,7 @@ function setupDialog() {
 }
 
 function tearDownDialog() {
-  act(() => {
-    useZustand.setState({
-      states: {},
-      tasks: {},
-    });
-  });
+  act(() => useZustand.getState().clear());
 }
 
 it("should add a state when pressed", async () => {

--- a/src/templates/KanbanBoard/AddTaskModal.test.tsx
+++ b/src/templates/KanbanBoard/AddTaskModal.test.tsx
@@ -8,23 +8,19 @@ jest.mock("./kanbanActions.ts");
 function setupDialog() {
   const stateId = "state-1";
   act(() => {
-    useZustand.setState({
-      states: {
-        [stateId]: {
+    useZustand.getState().setUser({ email: "test" });
+    useZustand.getState().initialize(
+      [],
+      [
+        {
           id: stateId,
           name: "To do",
           position: 100,
           color: "red",
           owner: "test",
         },
-      },
-      tasks: {
-        [stateId]: [],
-      },
-      user: {
-        email: "test",
-      },
-    });
+      ],
+    );
   });
   const onClose = jest.fn();
   render(<AddTaskModal isOpen={true} onClose={onClose} stateId={stateId} />);
@@ -33,12 +29,7 @@ function setupDialog() {
 }
 
 function tearDownDialog() {
-  act(() => {
-    useZustand.setState({
-      states: {},
-      tasks: {},
-    });
-  });
+  act(() => useZustand.getState().clear());
 }
 
 it("should add a task when pressed", async () => {
@@ -52,13 +43,15 @@ it("should add a task when pressed", async () => {
 
   expect(onClose).toHaveBeenCalled();
   const tasks = useZustand.getState().tasks;
-  expect(Object.values(tasks)).toHaveLength(1);
-  expect(tasks[stateId][0]).toMatchSnapshot(
-    {
-      id: expect.any(String),
-    },
-    "Tasks Result",
-  );
+  const tasksOrder = useZustand.getState().tasksOrder[stateId];
+  expect(Object.keys(tasks)).toHaveLength(1);
+  expect(tasksOrder).toHaveLength(1);
+  tasksOrder.forEach((taskId) => {
+    expect(tasks[taskId]).toMatchSnapshot(
+      { id: expect.any(String) },
+      "Tasks Result",
+    );
+  });
 
   tearDownDialog();
 });
@@ -88,13 +81,15 @@ it("should focus on the input component and submit when 'Enter' is pressed", asy
   await userEvent.type(textbox, "My new task 2{enter}");
   expect(onClose).toHaveBeenCalled();
   const tasks = useZustand.getState().tasks;
-  expect(Object.values(tasks[stateId])).toHaveLength(1);
-  expect(tasks[stateId][0]).toMatchSnapshot(
-    {
-      id: expect.any(String),
-    },
-    "States Result",
-  );
+  const tasksOrder = useZustand.getState().tasksOrder[stateId];
+  expect(Object.keys(tasks)).toHaveLength(1);
+  expect(tasksOrder).toHaveLength(1);
+  tasksOrder.forEach((taskId) => {
+    expect(tasks[taskId]).toMatchSnapshot(
+      { id: expect.any(String) },
+      "Tasks Result after pressing enter",
+    );
+  });
 
   tearDownDialog();
 });

--- a/src/templates/KanbanBoard/AddTaskModal.tsx
+++ b/src/templates/KanbanBoard/AddTaskModal.tsx
@@ -27,7 +27,7 @@ interface AddModalProps {
 export function AddTaskModal({ isOpen, onClose, stateId }: AddModalProps) {
   const user = useZustand((store) => store.user);
   const taskList = useZustand((store) =>
-    stateId ? store.tasks[stateId] : undefined,
+    stateId ? store.tasksOrder[stateId] : [],
   );
   const addTask = useZustand((store) => store.addTask);
   const [title, setTitle] = useState("");
@@ -39,7 +39,7 @@ export function AddTaskModal({ isOpen, onClose, stateId }: AddModalProps) {
       text: title,
       stateId,
       id: uuid(),
-      position: taskList ? taskList.length : 0,
+      position: taskList.length,
       owner: user.email,
     };
     addTaskDB(newTask);

--- a/src/templates/KanbanBoard/EditTaskModal.test.tsx
+++ b/src/templates/KanbanBoard/EditTaskModal.test.tsx
@@ -17,11 +17,7 @@ function setupDialog(task: Task) {
 }
 
 function tearDownDialog() {
-  act(() => {
-    useZustand.setState({
-      tasks: {},
-    });
-  });
+  act(() => useZustand.getState().clear());
 }
 
 it("should edit a task when pressed", async () => {

--- a/src/templates/KanbanBoard/Header.test.tsx
+++ b/src/templates/KanbanBoard/Header.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useRouter } from "next/navigation";
 import { Header } from "./Header";
@@ -22,10 +22,12 @@ it("should launch login when button is pressed", async () => {
 });
 
 it("should launch logout when button is pressed", async () => {
-  useZustand.setState({
-    user: {
-      email: "test",
-    },
+  act(() => {
+    useZustand.setState({
+      user: {
+        email: "test",
+      },
+    });
   });
 
   const { push } = (useRouter as jest.Mock)();
@@ -40,5 +42,5 @@ it("should launch logout when button is pressed", async () => {
   expect(clearCookies).toHaveBeenCalled();
   expect(push).toHaveBeenCalledWith("/login");
 
-  useZustand.setState({});
+  act(() => useZustand.getState().clear());
 });

--- a/src/templates/KanbanBoard/KanbanColumn.tsx
+++ b/src/templates/KanbanBoard/KanbanColumn.tsx
@@ -25,9 +25,7 @@ export function KanbanColumn({
   setEditTaskModalItem,
 }: KanbanColumnProps) {
   const state = useZustand((store) => store.states[stateId]);
-  const tasksOrder = useZustand((store) => store.tasksOrder);
   const taskList = useZustand((store) => store.tasksOrder[stateId] ?? []);
-  const moveTask = useZustand((store) => store.moveTask);
   const dropRef = useRef(null);
 
   const [_, drop] = useDrop<DraggedItemData>(
@@ -56,11 +54,11 @@ export function KanbanColumn({
           }
         }
 
-        const { tasks } = useZustand.getState();
-        let affectedIds = tasksOrder[stateFrom] ?? [];
+        const { tasks, tasksOrder, moveTask } = useZustand.getState();
+        let affectedIds = tasksOrder[stateId] ?? [];
         if (stateFrom !== stateId) {
-          const destinationColumnIds = tasksOrder[stateId] ?? [];
-          affectedIds = affectedIds.concat(destinationColumnIds);
+          const sourceTasksId = tasksOrder[stateFrom] ?? [];
+          affectedIds = sourceTasksId.concat(affectedIds);
         }
         const affectedTasks = affectedIds.map((id) => tasks[id]);
         moveTaskDB(affectedTasks, stateFrom, stateId, task, position);

--- a/src/templates/KanbanBoard/KanbanColumn.tsx
+++ b/src/templates/KanbanBoard/KanbanColumn.tsx
@@ -57,11 +57,12 @@ export function KanbanColumn({
         }
 
         const { tasks } = useZustand.getState();
-        const fromColumnTasksId = tasksOrder[stateFrom] ?? [];
-        const toColumnTasksId = tasksOrder[stateId] ?? [];
-        const affectedTasks = fromColumnTasksId
-          .concat(toColumnTasksId)
-          .map((id) => tasks[id]);
+        let affectedIds = tasksOrder[stateFrom] ?? [];
+        if (stateFrom !== stateId) {
+          const destinationColumnIds = tasksOrder[stateId] ?? [];
+          affectedIds = affectedIds.concat(destinationColumnIds);
+        }
+        const affectedTasks = affectedIds.map((id) => tasks[id]);
         moveTaskDB(affectedTasks, stateFrom, stateId, task, position);
         moveTask(task, stateFrom, stateId, position);
       },

--- a/src/templates/KanbanBoard/KanbanColumnList.tsx
+++ b/src/templates/KanbanBoard/KanbanColumnList.tsx
@@ -1,5 +1,4 @@
 import {
-  Box,
   Button,
   Card,
   CardBody,
@@ -11,23 +10,23 @@ import {
   Text,
 } from "@chakra-ui/react";
 import { KanbanColumn } from "./KanbanColumn";
-import { State as StateType, Task } from "./model";
+import { Task, useZustand } from "./model";
 
 interface KanbanColumnListProps {
   isStateDialogOpen: boolean;
-  sortedStates: StateType[];
   onOpenStateDialog(): void;
   onOpenCreateTaskModal(id: string): void;
   onOpenEditTaskModal(task: Task): void;
 }
 
 export function KanbanColumnList({
-  sortedStates,
   isStateDialogOpen,
   onOpenStateDialog,
   onOpenEditTaskModal,
   onOpenCreateTaskModal,
 }: KanbanColumnListProps) {
+  const sortedStates = useZustand((store) => store.statesOrder);
+
   if (sortedStates.length < 1) {
     return (
       <Center width="100%" height="100%">
@@ -61,11 +60,9 @@ export function KanbanColumnList({
     <Flex margin={4} direction="row" gap="2">
       {sortedStates.map((value) => (
         <KanbanColumn
-          key={value.name}
-          id={value.id}
-          title={value.name}
-          color={value.color}
-          onOpenCreateTaskModal={() => onOpenCreateTaskModal(value.id)}
+          key={value}
+          stateId={value}
+          onOpenCreateTaskModal={() => onOpenCreateTaskModal(value)}
           setEditTaskModalItem={onOpenEditTaskModal}
         />
       ))}

--- a/src/templates/KanbanBoard/KanbanItem.tsx
+++ b/src/templates/KanbanBoard/KanbanItem.tsx
@@ -10,18 +10,16 @@ export interface DraggedItemData {
 }
 
 interface ItemProps {
-  parentId: string;
-  itemData: Task;
-  color: string;
+  taskId: string;
   setTaskModalItem(task: Task): void;
 }
 
 export const KanbanItem: React.FC<ItemProps> = ({
-  parentId,
-  itemData,
-  color,
+  taskId,
   setTaskModalItem,
 }) => {
+  const itemData = useZustand((store) => store.tasks[taskId]);
+  const { color } = useZustand((store) => store.states[itemData.stateId]);
   const deleteTask = useZustand((store) => store.deleteTask);
 
   const [{ isDragging }, drag] = useDrag<
@@ -32,14 +30,14 @@ export const KanbanItem: React.FC<ItemProps> = ({
     {
       type: "Task",
       item: {
-        stateFrom: parentId,
+        stateFrom: itemData.stateId,
         task: itemData,
       },
       collect: (monitor) => ({
         isDragging: !!monitor.isDragging(),
       }),
     },
-    [parentId, itemData],
+    [itemData],
   );
 
   const handleDeleteTask = (id: string) => {

--- a/src/templates/KanbanBoard/Layout.test.tsx
+++ b/src/templates/KanbanBoard/Layout.test.tsx
@@ -6,23 +6,18 @@ import { useZustand } from "./model";
 jest.mock("./clearCookies.ts");
 jest.mock("./kanbanActions.ts");
 
-afterEach(() => {
-  useZustand.setState({
-    states: {},
-    tasks: {},
-    statesOrder: [],
-    tasksOrder: {},
-    user: {
-      email: "test",
-    },
-  });
-});
+function setup() {
+  act(() => useZustand.getState().setUser({ email: "test" }));
+}
 
-function setInitialState() {
+function tearDown() {
+  act(() => useZustand.getState().clear());
+}
+
+function initialize() {
   // NOTE: The state's positions are not in order!
   // They should get sorted by the component itself
   act(() => {
-    useZustand.getState().setUser({ email: "test" });
     useZustand.getState().initialize(
       [],
       [
@@ -53,7 +48,8 @@ function setInitialState() {
 }
 
 it("should render the sorted states", () => {
-  setInitialState();
+  setup();
+  initialize();
 
   const { container } = render(<Layout />);
   expect(container).toMatchSnapshot("Default Kanban Page");
@@ -62,10 +58,13 @@ it("should render the sorted states", () => {
     const element = screen.queryByText(stateTitle);
     expect(element).toBeInTheDocument();
   });
+
+  tearDown();
 });
 
 // it should render when empty
 it("should render when empty", () => {
+  setup();
   const { container } = render(<Layout />);
   expect(container).toMatchSnapshot("Empty Kanban Page");
 
@@ -73,9 +72,11 @@ it("should render when empty", () => {
     const element = screen.queryByText(stateTitle);
     expect(element).not.toBeInTheDocument();
   });
+  tearDown();
 });
 
 it("should open the AddStateModal when button is pressed", async () => {
+  setup();
   render(<Layout />);
 
   // Click the button
@@ -87,11 +88,14 @@ it("should open the AddStateModal when button is pressed", async () => {
   const modal = screen.getByRole("dialog");
   modal.setAttribute("style", ""); // This value has animation! We don't want that in our snapshot
   expect(modal).toMatchSnapshot("AddStateModal");
+
+  tearDown();
 });
 
 describe("sould create 10 random tasks when button is pressed", () => {
   it("should add new tasks on the first state", async () => {
-    setInitialState();
+    setup();
+    initialize();
     render(<Layout />);
 
     const createRandomTasksButton = await screen.findByTestId(
@@ -109,9 +113,11 @@ describe("sould create 10 random tasks when button is pressed", () => {
     await waitFor(() =>
       expect(within(state).getAllByTitle("task")).toHaveLength(10),
     );
+    tearDown();
   });
 
   it("should add new tasks on a new state", async () => {
+    setup();
     render(<Layout />);
 
     const createRandomTasksButton = await screen.findByTestId(
@@ -129,5 +135,7 @@ describe("sould create 10 random tasks when button is pressed", () => {
     randomState = screen.getByTitle("Random State");
     await waitFor(() => expect(randomState).toBeInTheDocument());
     expect(within(randomState).getAllByTitle("task")).toHaveLength(10);
+
+    tearDown();
   });
 });

--- a/src/templates/KanbanBoard/Layout.test.tsx
+++ b/src/templates/KanbanBoard/Layout.test.tsx
@@ -10,6 +10,8 @@ afterEach(() => {
   useZustand.setState({
     states: {},
     tasks: {},
+    statesOrder: [],
+    tasksOrder: {},
     user: {
       email: "test",
     },
@@ -20,36 +22,33 @@ function setInitialState() {
   // NOTE: The state's positions are not in order!
   // They should get sorted by the component itself
   act(() => {
-    useZustand.setState({
-      states: {
-        "state-1": {
+    useZustand.getState().setUser({ email: "test" });
+    useZustand.getState().initialize(
+      [],
+      [
+        {
           id: "state-1",
           name: "To do",
           position: 100,
           color: "red",
           owner: "test",
         },
-        "state-2": {
+        {
           id: "state-2",
           name: "In progress",
           position: 0,
           color: "blue",
           owner: "test",
         },
-        "state-3": {
+        {
           id: "state-3",
           name: "Done",
           position: 3,
           color: "green",
           owner: "test",
         },
-      },
-      tasks: {
-        "state-1": [],
-        "state-2": [],
-        "state-3": [],
-      },
-    });
+      ],
+    );
   });
 }
 

--- a/src/templates/KanbanBoard/Layout.tsx
+++ b/src/templates/KanbanBoard/Layout.tsx
@@ -1,5 +1,4 @@
 import { Box } from "@chakra-ui/react";
-import { useMemo } from "react";
 import { v4 as uuid } from "uuid";
 import { AddStateModal } from "./AddStateModal";
 import { AddTaskModal } from "./AddTaskModal";
@@ -14,43 +13,41 @@ export function Layout() {
   const user = useZustand((store) => store.user);
   const addState = useZustand((store) => store.addState);
   const addTask = useZustand((store) => store.addTask);
-  const states = useZustand((store) => store.states);
-  const tasks = useZustand((store) => store.tasks);
   const [modals, dispatch] = useModalState();
-
-  const sortedStates = useMemo(() => {
-    return Object.values(states).sort(
-      (valueA, valueB) => valueA.position - valueB.position,
-    );
-  }, [states]);
 
   const handleCreateRandomTasks = () => {
     if (!user) return;
+
+    console.log("handleCreateRandomTasks");
+
+    const sortedStates = useZustand.getState().statesOrder;
     const randomTasks = new Set<string>();
-    let firstState: StateType;
+    let firstStateId: string;
 
     if (!sortedStates.length) {
-      firstState = {
-        id: uuid(),
+      firstStateId = uuid();
+      const item: StateType = {
+        id: firstStateId,
         name: "Random State",
         color: "black",
         position: 0,
         owner: user.email,
       };
-      addStateDB(firstState);
-      addState(firstState);
+      addStateDB(item);
+      addState(item);
     } else {
-      firstState = sortedStates[0];
+      firstStateId = sortedStates[0];
     }
 
-    let position = firstState.id in tasks ? tasks[firstState.id].length : 0;
     while (randomTasks.size < 10) {
       randomTasks.add(`Random Task ${Math.floor(Math.random() * 100)}`);
     }
+
+    let position = sortedStates.length ?? 0;
     randomTasks.forEach((task) => {
       const newTask = {
         text: task,
-        stateId: firstState.id,
+        stateId: firstStateId,
         id: uuid(),
         position: position,
         owner: user.email,
@@ -71,7 +68,6 @@ export function Layout() {
       <Box overflowX="auto" flex="1">
         <KanbanColumnList
           isStateDialogOpen={modals.addStateIsOpen}
-          sortedStates={sortedStates}
           onOpenStateDialog={() => dispatch({ key: "ADD_STATE::OPEN" })}
           onOpenEditTaskModal={(task) =>
             dispatch({ key: "EDIT_TASK::OPEN", payload: { task } })

--- a/src/templates/KanbanBoard/Layout.tsx
+++ b/src/templates/KanbanBoard/Layout.tsx
@@ -18,8 +18,6 @@ export function Layout() {
   const handleCreateRandomTasks = () => {
     if (!user) return;
 
-    console.log("handleCreateRandomTasks");
-
     const sortedStates = useZustand.getState().statesOrder;
     const randomTasks = new Set<string>();
     let firstStateId: string;

--- a/src/templates/KanbanBoard/__snapshots__/AddTaskModal.test.tsx.snap
+++ b/src/templates/KanbanBoard/__snapshots__/AddTaskModal.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`should add a task when pressed: Tasks Result 1`] = `
 }
 `;
 
-exports[`should focus on the input component and submit when 'Enter' is pressed: States Result 1`] = `
+exports[`should focus on the input component and submit when 'Enter' is pressed: Tasks Result after pressing enter 1`] = `
 {
   "id": Any<String>,
   "owner": "test",

--- a/src/templates/KanbanBoard/__snapshots__/Layout.test.tsx.snap
+++ b/src/templates/KanbanBoard/__snapshots__/Layout.test.tsx.snap
@@ -222,11 +222,11 @@ exports[`should render the sorted states: Default Kanban Page 1`] = `
                 class="chakra-avatar css-332l87"
               >
                 <div
-                  aria-label="guest"
+                  aria-label="test"
                   class="chakra-avatar__initials css-0"
                   role="img"
                 >
-                  g
+                  t
                 </div>
               </span>
             </span>
@@ -251,11 +251,11 @@ exports[`should render the sorted states: Default Kanban Page 1`] = `
                   class="chakra-avatar css-332l87"
                 >
                   <div
-                    aria-label="guest"
+                    aria-label="test"
                     class="chakra-avatar__initials css-0"
                     role="img"
                   >
-                    g
+                    t
                   </div>
                 </span>
               </div>
@@ -264,7 +264,7 @@ exports[`should render the sorted states: Default Kanban Page 1`] = `
                 class="css-gmuwbf"
               >
                 <p>
-                  guest
+                  test
                    
                 </p>
               </div>
@@ -276,13 +276,13 @@ exports[`should render the sorted states: Default Kanban Page 1`] = `
               <button
                 class="chakra-menu__menuitem css-1k756t9"
                 data-index="0"
-                data-testid="login-button"
+                data-testid="logout-button"
                 id="menu-list-:r6:-menuitem-:r7:"
                 role="menuitem"
                 tabindex="-1"
                 type="button"
               >
-                Login / Register
+                Logout
               </button>
             </div>
           </div>

--- a/src/templates/KanbanBoard/index.tsx
+++ b/src/templates/KanbanBoard/index.tsx
@@ -14,7 +14,7 @@ import { useZustand } from "./model";
 export interface KanbanProps {
   initialStates: StateDTO[];
   initialTasks: TaskDTO[];
-  initialUser?: UserDTO;
+  initialUser: UserDTO;
 }
 
 export function KanbanBoard({
@@ -22,12 +22,17 @@ export function KanbanBoard({
   initialTasks,
   initialUser,
 }: KanbanProps) {
+  const setUser = useZustand((store) => store.setUser);
   const initialize = useZustand((store) => store.initialize);
 
   // Initialize zustand with the server-side data
   useEffect(() => {
-    initialize(initialTasks, initialStates, initialUser);
-  }, [initialStates, initialTasks, initialUser, initialize]);
+    initialize(initialTasks, initialStates);
+  }, [initialStates, initialTasks, initialize]);
+
+  useEffect(() => {
+    setUser(initialUser);
+  }, [initialUser, setUser]);
 
   return (
     <ChakraProvider theme={theme}>

--- a/src/templates/KanbanBoard/model/index.ts
+++ b/src/templates/KanbanBoard/model/index.ts
@@ -53,7 +53,8 @@ const stateCreator: StateCreator<KanbanState & KanbanActions> = (set, get) => ({
 
   addTask: (newTask) => {
     const tasks = produce(get().tasks, (draft) => {
-      draft[newTask.stateId] = newTask;
+      draft[newTask.id] = newTask;
+      return draft;
     });
 
     const tasksOrder = produce(get().tasksOrder, (draft) => {
@@ -61,6 +62,7 @@ const stateCreator: StateCreator<KanbanState & KanbanActions> = (set, get) => ({
         draft[newTask.stateId] = [];
       }
       draft[newTask.stateId].push(newTask.id);
+      return draft;
     });
 
     set({ tasks, tasksOrder });
@@ -86,6 +88,7 @@ const stateCreator: StateCreator<KanbanState & KanbanActions> = (set, get) => ({
 
       draftState[fromStateId] = sourceState;
       draftState[toStateId] = destinationState;
+      return draftState;
     });
 
     set({ tasksOrder: newTasksOrder });
@@ -94,14 +97,17 @@ const stateCreator: StateCreator<KanbanState & KanbanActions> = (set, get) => ({
   addState: (newState) => {
     const tasksOrder = produce(get().tasksOrder, (draft) => {
       draft[newState.id] = [];
+      return draft;
     });
 
     const statesOrder = produce(get().statesOrder, (draft) => {
       draft.push(newState.id);
+      return draft;
     });
 
     const states = produce(get().states, (draft) => {
       draft[newState.id] = newState;
+      return draft;
     });
 
     set({ states, tasksOrder, statesOrder });
@@ -111,6 +117,7 @@ const stateCreator: StateCreator<KanbanState & KanbanActions> = (set, get) => ({
   editTask: (taskId, updatedValues) => {
     const tasks = produce(get().tasks, (draft) => {
       draft[taskId] = { ...draft[taskId], ...updatedValues };
+      return draft;
     });
 
     set({ tasks });
@@ -120,10 +127,12 @@ const stateCreator: StateCreator<KanbanState & KanbanActions> = (set, get) => ({
     const { stateId } = get().tasks[taskId];
     const tasksOrder = produce(get().tasksOrder, (draft) => {
       draft[stateId] = draft[stateId].filter((id) => id !== taskId);
+      return draft;
     });
 
     const tasks = produce(get().tasks, (draft) => {
       delete draft[taskId];
+      return draft;
     });
 
     set({ tasks, tasksOrder });

--- a/src/templates/KanbanBoard/model/index.ts
+++ b/src/templates/KanbanBoard/model/index.ts
@@ -5,11 +5,16 @@ import { KanbanState, KanbanActions } from "./state";
 
 export type { State, Task } from "./types";
 
-const stateCreator: StateCreator<KanbanState & KanbanActions> = (set, get) => ({
+const defaultState: KanbanState = {
   statesOrder: [],
   tasksOrder: {},
   tasks: {},
   states: {},
+  user: undefined,
+};
+
+const stateCreator: StateCreator<KanbanState & KanbanActions> = (set, get) => ({
+  ...defaultState,
 
   initialize(initialTasks, initialStates) {
     const statesOrderSparseArray: string[] = [];
@@ -136,6 +141,10 @@ const stateCreator: StateCreator<KanbanState & KanbanActions> = (set, get) => ({
     });
 
     set({ tasks, tasksOrder });
+  },
+
+  clear: () => {
+    set({ ...defaultState });
   },
 });
 

--- a/src/templates/KanbanBoard/model/state.ts
+++ b/src/templates/KanbanBoard/model/state.ts
@@ -1,0 +1,47 @@
+import { StateDTO } from "@/model/State";
+import { TaskDTO } from "@/model/Task";
+import { UserDTO } from "@/model/User";
+import { Immutable } from "immer";
+import { State, Task } from "./types";
+
+export type KanbanState = Immutable<{
+  /**
+   * The order of the states in the board.
+   */
+  statesOrder: string[];
+
+  /**
+   * The order of the tasks in each state.
+   */
+  tasksOrder: Record<string, string[]>;
+
+  /**
+   * Key: taskId. Value: Task.
+   */
+  tasks: Record<string, Task>;
+
+  /**
+   * Key: stateId. Value: State.
+   */
+  states: Record<string, State>;
+
+  /**
+   * The user that is currently logged in
+   */
+  user?: UserDTO;
+}>;
+
+export interface KanbanActions {
+  setUser(user?: UserDTO): void;
+  initialize(initialTasks: TaskDTO[], initialStates: StateDTO[]): void;
+  addTask(newTask: Task): Task;
+  moveTask(
+    newTask: Task,
+    fromStateId: string,
+    toStateId: string,
+    position: number,
+  ): void;
+  addState(newState: State): State;
+  editTask(id: string, updatedValues: Partial<Task>): void;
+  deleteTask: (id: string) => void;
+}

--- a/src/templates/KanbanBoard/model/state.ts
+++ b/src/templates/KanbanBoard/model/state.ts
@@ -44,4 +44,6 @@ export interface KanbanActions {
   addState(newState: State): State;
   editTask(id: string, updatedValues: Partial<Task>): void;
   deleteTask: (id: string) => void;
+
+  clear(): void;
 }


### PR DESCRIPTION
* Refactored the Zustand state to be able to store the column ordering.
* Task Items now only rerender when their ID changes.
* Column Items now only rerender when the Column Id or the inner tasks ordering changes.